### PR TITLE
Out of Sync Tail

### DIFF
--- a/Queue.cpp
+++ b/Queue.cpp
@@ -23,6 +23,9 @@ bool Queue::enqueue(uint8_t type, uint32_t value){
 		if(tail<Q_SIZE){
 			buffer[tail][type] = value;
 			tail++;
+			if(tail==Q_SIZE){
+				tail=0;
+			}
 			return true;
 		}
 		else if(tail==Q_SIZE){


### PR DESCRIPTION
Tail was out of sync with the index, it would reach the tail size of max (index max+1) and unless the queue was completely emptied, it would glitch and get out of sync